### PR TITLE
Add graphql-subscriptions when running locally

### DIFF
--- a/src/FanoutGraphqlApolloConfig.ts
+++ b/src/FanoutGraphqlApolloConfig.ts
@@ -1,8 +1,14 @@
-import { gql } from "apollo-server-core";
+import { PubSub } from "apollo-server";
+import { Context, gql, SubscriptionServerOptions } from "apollo-server-core";
 import { Config as ApolloServerConfig } from "apollo-server-core";
+import { ExpressContext } from "apollo-server-express/dist/ApolloServer";
 import { IResolvers } from "graphql-tools";
 import * as uuidv4 from "uuid/v4";
 import { ISimpleTable } from "./SimpleTable";
+
+enum SubscriptionEventNames {
+  noteAdded = "noteAdded",
+}
 
 export interface INote {
   /** unique identifier for the note */
@@ -16,17 +22,32 @@ export interface IFanoutGraphqlTables {
   notes: ISimpleTable<INote>;
 }
 
-/** ApolloServer.Config that will configure an ApolloServer to serve the FanoutGraphql graphql API */
+interface IFanoutGraphqlAppContext {
+  /** Authorization token, if present */
+  authorization: string | undefined;
+}
+
+/**
+ * ApolloServer.Config that will configure an ApolloServer to serve the FanoutGraphql graphql API.
+ * @param pubsub - If not provided, subscriptions will not be enabled
+ */
 export const FanoutGraphqlApolloConfig = (
   tables: IFanoutGraphqlTables,
+  pubsub?: PubSub,
 ): ApolloServerConfig => {
+  if (!pubsub) {
+    console.debug(
+      "FanoutGraphqlApolloConfig: no pubsub provided. Subscriptions will be disabled.",
+    );
+  }
+
   // Construct a schema, using GraphQL schema language
   const typeDefs = gql`
-    type Note {
-      content: String!
-    }
     input AddNoteInput {
       "The main body content of the Note"
+      content: String!
+    }
+    type Note {
       content: String!
     }
     type Query {
@@ -36,18 +57,31 @@ export const FanoutGraphqlApolloConfig = (
     type Mutation {
       addNote(note: AddNoteInput!): Note
     }
+    ${pubsub
+      ? `
+      type Subscription {
+        noteAdded: Note!
+      }
+      `
+      : ""}
   `;
 
   // Provide resolver functions for your schema fields
   const resolvers: IResolvers = {
     Mutation: {
-      async addNote(root, { note }) {
+      async addNote(root, args) {
+        const { note } = args;
         const noteId = uuidv4();
         const noteToInsert = {
           ...note,
           id: noteId,
         };
         await tables.notes.insert(noteToInsert);
+        if (pubsub) {
+          pubsub.publish(SubscriptionEventNames.noteAdded, {
+            noteAdded: noteToInsert,
+          });
+        }
         return noteToInsert;
       },
     },
@@ -57,9 +91,57 @@ export const FanoutGraphqlApolloConfig = (
         return tables.notes.scan();
       },
     },
+    ...(pubsub
+      ? {
+          Subscription: {
+            noteAdded: {
+              subscribe() {
+                return pubsub.asyncIterator([SubscriptionEventNames.noteAdded]);
+              },
+            },
+          },
+        }
+      : {}),
   };
 
-  return { typeDefs, resolvers };
+  const subscriptions: Partial<SubscriptionServerOptions> = {
+    onConnect(connectionParams, websocket, context) {
+      console.log("FanoutGraphqlApolloConfig subscription onConnect");
+    },
+    onDisconnect() {
+      console.log("FanoutGraphqlApolloConfig subscription onDisconnect");
+    },
+  };
+
+  interface ISubscriptionContextOptions {
+    /** graphql context to use for subscription */
+    context: Context;
+  }
+
+  const createContext = async (
+    contextOptions: ExpressContext | ISubscriptionContextOptions,
+  ): Promise<IFanoutGraphqlAppContext> => {
+    console.log("FanoutGraphqlServer constructing with contextOptions");
+    const connectionContext =
+      "context" in contextOptions ? contextOptions.context : {};
+    const contextFromExpress =
+      "req" in contextOptions
+        ? { authorization: contextOptions.req.headers.authorization }
+        : {};
+    const context: IFanoutGraphqlAppContext = {
+      authorization: undefined,
+      ...connectionContext,
+      ...contextFromExpress,
+    };
+    return context;
+  };
+
+  return {
+    context: createContext,
+    resolvers,
+    subscriptions: pubsub && subscriptions,
+    typeDefs,
+  };
 };
 
 export default FanoutGraphqlApolloConfig;

--- a/src/FanoutGraphqlServer.ts
+++ b/src/FanoutGraphqlServer.ts
@@ -1,4 +1,4 @@
-import { ApolloServer } from "apollo-server";
+import { ApolloServer, PubSub } from "apollo-server";
 import FanoutGraphqlApolloConfig, {
   IFanoutGraphqlTables,
   INote,
@@ -9,7 +9,9 @@ import { MapSimpleTable } from "./SimpleTable";
  * ApolloServer configured for FanoutGraphql (not in lambda).
  */
 export const FanoutGraphqlServer = (tables: IFanoutGraphqlTables) => {
-  const apolloServer = new ApolloServer(FanoutGraphqlApolloConfig(tables));
+  const apolloServer = new ApolloServer({
+    ...FanoutGraphqlApolloConfig(tables, new PubSub()),
+  });
   return apolloServer;
 };
 
@@ -17,8 +19,9 @@ const main = async () => {
   const server = FanoutGraphqlServer({
     notes: MapSimpleTable<INote>(),
   });
-  server.listen(process.env.PORT || 0).then(({ url }) => {
+  server.listen(process.env.PORT || 0).then(({ url, subscriptionsUrl }) => {
     console.log(`🚀 Server ready at ${url}`);
+    console.log(`🚀 Subscriptions ready at ${subscriptionsUrl}`);
   });
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "downlevelIteration": true
   },
   "exclude": ["node_modules/**"]
 }


### PR DESCRIPTION
Uses apollo-server default PubSub implementation, which is an in-memory EventEmitter-backed thing that won't work in Lambda. Therefore, subscriptions at this point are not enabled in the ApolloServer used by `FanoutGraphqlAppLambdaCallback`. But they work locally.

There are more alternative PubSubEngine implementations that can be injected in, e.g. https://github.com/apollographql/graphql-subscriptions#pubsub-implementations