### PR TITLE
Delete subscriptions on gql stop

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,20 @@
       "type": "node",
       "request": "launch",
       "args": ["${relativeFile}"],
-      "runtimeArgs": ["-r", "ts-node/register"],
+      "runtimeArgs": [
+        "--nolazy",
+        "--preserve-symlinks",
+        "--preserve-symlinks-main",
+        "-r", "ts-node/register"
+      ],
       "cwd": "${workspaceRoot}",
       "protocol": "inspector",
       "internalConsoleOptions": "openOnSessionStart",
       "outputCapture": "std",
+      "sourceMaps": true,
       "env": {
         "LOG_LEVEL": "debug",
-        "TEST_TIMEOUT_MS": "60000",
+        "TEST_TIMEOUT_MS": "60000"
       }
     },
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1295,9 +1295,9 @@
       "integrity": "sha1-MDJeDPbC+l+RAj0hAO0CGCbmMX0="
     },
     "fanout-graphql-tools": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.0.tgz",
-      "integrity": "sha512-1Ti1v+Z7znLA7IeTMVGY8F1nCL4dETB0F/+i4nVx6UmOir64ru20fpIBv8T6EylHwFAwDTS98GVcdT5X/J4+MQ==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.1.tgz",
+      "integrity": "sha512-fLBdUuzlnpfE7nT65SEqnYBY/lhXsN+PtVX+Sb2x1IN3HzB7gwSznpHwzV4GsgaItnG4GSJYDYcrRvnyhvfh2w==",
       "requires": {
         "@types/core-js": "^2.5.0",
         "@types/graphql": "^14.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "body-parser": "^1.18.3",
     "core-js": "^3.1.3",
     "cross-fetch": "^3.0.2",
-    "fanout-graphql-tools": "0.0.0",
+    "fanout-graphql-tools": "0.0.1",
     "fp-ts": "^1.17.0",
     "graphql": "^14.3.1",
     "grip": "^1.4.0",

--- a/src/FanoutGraphqlApolloConfig.ts
+++ b/src/FanoutGraphqlApolloConfig.ts
@@ -22,6 +22,7 @@ import {
 import { IGraphqlSubscription } from "fanout-graphql-tools/dist/src/subscriptions-transport-ws-over-http/GraphqlSubscription";
 import { GraphQLSchema } from "graphql";
 import { withFilter } from "graphql-subscriptions";
+import gql from "graphql-tag";
 import { IResolvers, makeExecutableSchema } from "graphql-tools";
 import { $$asyncIterator } from "iterall";
 import * as querystring from "querystring";
@@ -29,14 +30,32 @@ import * as uuidv4 from "uuid/v4";
 
 /** Common queries for this API */
 export const FanoutGraphqlSubscriptionQueries = {
-  noteAdded: `
-    subscription {
-      noteAdded {
-        content,
-        id,
-      }
-    }
-  `,
+  noteAdded() {
+    return {
+      query: gql`
+        subscription {
+          noteAdded {
+            content
+            id
+          }
+        }
+      `,
+      variables: {},
+    };
+  },
+  noteAddedToChannel(channel: string) {
+    return {
+      query: gql`
+        subscription NoteAddedToChannel($channel: String!) {
+          noteAddedToChannel(channel: $channel) {
+            content
+            id
+          }
+        }
+      `,
+      variables: { channel },
+    };
+  },
 };
 
 enum SubscriptionEventNames {

--- a/src/FanoutGraphqlApolloConfig.ts
+++ b/src/FanoutGraphqlApolloConfig.ts
@@ -19,6 +19,7 @@ import {
   IGraphqlWsStartMessage,
   isGraphqlWsStartMessage,
 } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools/dist/src/subscriptions-transport-ws-over-http/GraphqlSubscription";
 import { GraphQLSchema } from "graphql";
 import { withFilter } from "graphql-subscriptions";
 import { IResolvers, makeExecutableSchema } from "graphql-tools";
@@ -50,20 +51,6 @@ export interface INote {
   channel: string;
   /** main body content of the Note */
   content: string;
-}
-
-export interface IGraphqlSubscription {
-  /** unique identifier for the subscription */
-  id: string;
-  /** Provided by the subscribing client in graphql-ws 'GQL_START' message. Must be sent in each published 'GQL_DATA' message */
-  operationId: string;
-  /**
-   * The GQL_START message that started the subscription. It includes the query and stuff.
-   * https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_start
-   */
-  startMessage: string;
-  /** The name of the field in the GraphQL Schema being subscribed to. i.e. what you probably think of as the subscription name */
-  subscriptionFieldName: string;
 }
 
 export interface IFanoutGraphqlTables {

--- a/src/FanoutGraphqlExpressServer.ts
+++ b/src/FanoutGraphqlExpressServer.ts
@@ -11,6 +11,7 @@ import * as express from "express";
 import { EpcpPubSubMixin } from "fanout-graphql-tools";
 import { MapSimpleTable } from "fanout-graphql-tools";
 import { GraphqlWsOverWebSocketOverHttpExpressMiddleware } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools/dist/src/subscriptions-transport-ws-over-http/GraphqlSubscription";
 import gql from "graphql-tag";
 import * as http from "http";
 import { ConnectionContext } from "subscriptions-transport-ws";
@@ -21,7 +22,6 @@ import FanoutGraphqlApolloConfig, {
   FanoutGraphqlGripChannelsForSubscription,
   FanoutGraphqlTypeDefs,
   IFanoutGraphqlTables,
-  IGraphqlSubscription,
   INote,
 } from "./FanoutGraphqlApolloConfig";
 

--- a/src/FanoutGraphqlExpressServer.ts
+++ b/src/FanoutGraphqlExpressServer.ts
@@ -133,6 +133,8 @@ interface IFanoutGraphqlExpressServerOptions {
   tables: IFanoutGraphqlTables;
   /** called whenever a new GraphQL subscription connects */
   onSubscriptionConnection?: (...args: any[]) => any;
+  /** called when a GraphQL subscription is stopped */
+  onSubscriptionStop?: (...args: any[]) => any;
   /** pubsub engine to use for pubsub */
   pubsub?: PubSubEngine;
 }
@@ -187,6 +189,7 @@ export const FanoutGraphqlExpressServer = (
         ? GraphqlWsOverWebSocketOverHttpExpressMiddleware({
             getGripChannel: FanoutGraphqlGripChannelsForSubscription,
             onSubscriptionStart: onSubscriptionConnection,
+            onSubscriptionStop: options.onSubscriptionStop,
             subscriptionStorage: options.tables.subscriptions,
           })
         : (req, res, next) => next(),

--- a/src/FanoutGraphqlExpressServerTest.test.ts
+++ b/src/FanoutGraphqlExpressServerTest.test.ts
@@ -25,6 +25,7 @@ import {
 import { cli } from "./test/cli";
 import {
   FanoutGraphqlHttpAtUrlTest,
+  itemsFromLinkObservable,
   timer,
 } from "./test/testFanoutGraphqlAtUrl";
 import WebSocketApolloClient from "./WebSocketApolloClient";
@@ -202,10 +203,9 @@ export class FanoutGraphqlExpressServerTestSuite {
         ),
       };
       const apolloClient = WebSocketApolloClient(urls);
-      const subscriptionObservable = apolloClient.subscribe({
-        query: gql(FanoutGraphqlSubscriptionQueries.noteAdded),
-        variables: {},
-      });
+      const subscriptionObservable = apolloClient.subscribe(
+        FanoutGraphqlSubscriptionQueries.noteAdded(),
+      );
       const subscriptionGotItems: any[] = [];
       const { unsubscribe } = subscriptionObservable.subscribe({
         next(item) {
@@ -298,6 +298,74 @@ export class FanoutGraphqlExpressServerTestSuite {
         socketChangedEvent,
       );
       return;
+    });
+  }
+  /**
+   * Test that the server deletes rows from the subscription table after a subscription cleanly closes.
+   */
+  @AsyncTest()
+  @Timeout(1000 * 60 * 10)
+  public async testFanoutGraphqlExpressServerThroughPushpinDeletesSubscriptionAfterGqlWsStop(
+    graphqlPort = 57410,
+    pushpinProxyUrl = "http://localhost:7999",
+    pushpinGripUrl = "http://localhost:5561",
+  ) {
+    const [setLatestSocket, _, socketChangedEvent] = ChangingValue();
+    const [
+      setLastSubscriptionStop,
+      ,
+      lastSubscriptionStopChange,
+    ] = ChangingValue();
+    const subscriptions = MapSimpleTable<IGraphqlSubscription>();
+    const fanoutGraphqlExpressServer = FanoutGraphqlExpressServer({
+      grip: {
+        url: pushpinGripUrl,
+      },
+      onSubscriptionConnection: setLatestSocket,
+      onSubscriptionStop: setLastSubscriptionStop,
+      tables: {
+        notes: MapSimpleTable<INote>(),
+        subscriptions,
+      },
+    });
+    await withListeningServer(
+      fanoutGraphqlExpressServer.httpServer,
+      graphqlPort,
+    )(async () => {
+      // We're going to make a new ApolloClient to subscribe with, and assert that starting and stopping subscriptions results in the expected number of rows in subscriptions table.
+      const apolloClient = WebSocketApolloClient({
+        subscriptionsUrl: urlWithPath(
+          pushpinProxyUrl,
+          fanoutGraphqlExpressServer.subscriptionsPath,
+        ),
+        url: urlWithPath(
+          pushpinProxyUrl,
+          fanoutGraphqlExpressServer.graphqlPath,
+        ),
+      });
+
+      // Before any subscriptions, there should be 0 subscriptions stored
+      const storedSubscriptionsBeforeSubscribe = await subscriptions.scan();
+      Expect(storedSubscriptionsBeforeSubscribe.length).toEqual(0);
+
+      // Subscribe
+      const noteAddedObservable = apolloClient.subscribe(
+        FanoutGraphqlSubscriptionQueries.noteAdded(),
+      );
+      const { items, subscription } = itemsFromLinkObservable(
+        noteAddedObservable,
+      );
+      await socketChangedEvent();
+      // Now that the subscription is established, there should be one stored subscription
+      const storedSubscriptionsOnceSubscribed = await subscriptions.scan();
+      Expect(storedSubscriptionsOnceSubscribed.length).toEqual(1);
+
+      // Now we'll unsubscribe and then make sure the stored subscription is deleted
+      subscription.unsubscribe();
+      await lastSubscriptionStopChange();
+      // There should be no more stored subscriptions
+      const storedSubscriptionsAfterUnsubscribe = await subscriptions.scan();
+      Expect(storedSubscriptionsAfterUnsubscribe.length).toEqual(0);
     });
   }
 }

--- a/src/FanoutGraphqlExpressServerTest.test.ts
+++ b/src/FanoutGraphqlExpressServerTest.test.ts
@@ -9,13 +9,13 @@ import {
 import { gql, PubSub } from "apollo-server-express";
 import { EventEmitter } from "events";
 import { MapSimpleTable } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools/dist/src/subscriptions-transport-ws-over-http/GraphqlSubscription";
 import * as http from "http";
 import * as killable from "killable";
 import { AddressInfo } from "net";
 import * as url from "url";
 import {
   FanoutGraphqlSubscriptionQueries,
-  IGraphqlSubscription,
   INote,
 } from "./FanoutGraphqlApolloConfig";
 import {

--- a/src/examples/apollo-server-express-api.ts
+++ b/src/examples/apollo-server-express-api.ts
@@ -10,12 +10,12 @@ import * as express from "express";
 import { EpcpPubSubMixin } from "fanout-graphql-tools";
 import { GraphqlWsOverWebSocketOverHttpExpressMiddleware } from "fanout-graphql-tools";
 import { MapSimpleTable } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools";
 import * as http from "http";
 import FanoutGraphqlApolloConfig, {
   FanoutGraphqlEpcpPublishesForPubSubEnginePublish,
   FanoutGraphqlGripChannelsForSubscription,
   FanoutGraphqlTypeDefs,
-  IGraphqlSubscription,
 } from "../FanoutGraphqlApolloConfig";
 
 const PORT = process.env.PORT || 4000;

--- a/src/examples/http-request-listener-api.ts
+++ b/src/examples/http-request-listener-api.ts
@@ -11,13 +11,13 @@ import {
   GraphqlWsOverWebSocketOverHttpRequestListener,
   MapSimpleTable,
 } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools";
 import * as http from "http";
 import { run as microRun } from "micro";
 import FanoutGraphqlApolloConfig, {
   FanoutGraphqlEpcpPublishesForPubSubEnginePublish,
   FanoutGraphqlGripChannelsForSubscription,
   FanoutGraphqlTypeDefs,
-  IGraphqlSubscription,
 } from "../FanoutGraphqlApolloConfig";
 
 // Build a schema from typedefs here but without resolvers (since they will need the resulting pubsub to publish to)

--- a/src/examples/http-server-api.ts
+++ b/src/examples/http-server-api.ts
@@ -9,13 +9,13 @@ import { ApolloServer } from "apollo-server-micro";
 import { EpcpPubSubMixin } from "fanout-graphql-tools";
 import { MapSimpleTable } from "fanout-graphql-tools";
 import { GraphqlWsOverWebSocketOverHttpSubscriptionHandlerInstaller } from "fanout-graphql-tools";
+import { IGraphqlSubscription } from "fanout-graphql-tools";
 import * as http from "http";
 import micro from "micro";
 import FanoutGraphqlApolloConfig, {
   FanoutGraphqlEpcpPublishesForPubSubEnginePublish,
   FanoutGraphqlGripChannelsForSubscription,
   FanoutGraphqlTypeDefs,
-  IGraphqlSubscription,
 } from "../FanoutGraphqlApolloConfig";
 
 // Build a schema from typedefs here but without resolvers (since they will need the resulting pubsub to publish to)


### PR DESCRIPTION
When graphql-ws clients send a [GQL_STOP](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_stop) message indicating stopping a subscription, we now delete that subscription from the db.

To do this we also needed to start tracking a `connectionId` column on each row in the subscriptions table.

Much of the underlying logic for this comes from fanout-graphql-tools@0.0.1. e.g. this commit https://github.com/fanout/fanout-graphql-tools/commit/a15220e350e3a9e835a266bed02ea8b0dc383e82