### PR TITLE
Connection Storage, Expiration, Subscription cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1295,9 +1295,9 @@
       "integrity": "sha1-MDJeDPbC+l+RAj0hAO0CGCbmMX0="
     },
     "fanout-graphql-tools": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.4.tgz",
-      "integrity": "sha512-MLD6uhPcw85R7nnzgxUaz00GeezUL2pxFkihsYGe6doRiXj2BggrsSWZLJwoPRJ+ERLsrDqW0VxC/d0wLvomog==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.6.tgz",
+      "integrity": "sha512-ew13qkYvFakvbZdutpiEwBX3rtaP5y2M5HusDj6mNIUTjwFC5NLyuxL3QNebSfNobdTCiCPn/7yQ3ptpa/TniA==",
       "requires": {
         "@types/core-js": "^2.5.0",
         "@types/graphql": "^14.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1295,9 +1295,9 @@
       "integrity": "sha1-MDJeDPbC+l+RAj0hAO0CGCbmMX0="
     },
     "fanout-graphql-tools": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.3.tgz",
-      "integrity": "sha512-bj+sxHtZ9lxNyonYAw5unK0kZASJQisfbenv4Dpl+iKHJICjtlXxc0wZJ/3d7xM07t5NuqWWF9d/lzDBeRsCBw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fanout-graphql-tools/-/fanout-graphql-tools-0.0.4.tgz",
+      "integrity": "sha512-MLD6uhPcw85R7nnzgxUaz00GeezUL2pxFkihsYGe6doRiXj2BggrsSWZLJwoPRJ+ERLsrDqW0VxC/d0wLvomog==",
       "requires": {
         "@types/core-js": "^2.5.0",
         "@types/graphql": "^14.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "body-parser": "^1.18.3",
     "core-js": "^3.1.3",
     "cross-fetch": "^3.0.2",
-    "fanout-graphql-tools": "^0.0.4",
+    "fanout-graphql-tools": "0.0.6",
     "fp-ts": "^1.17.0",
     "graphql": "^14.3.1",
     "grip": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "body-parser": "^1.18.3",
     "core-js": "^3.1.3",
     "cross-fetch": "^3.0.2",
-    "fanout-graphql-tools": "^0.0.3",
+    "fanout-graphql-tools": "^0.0.4",
     "fp-ts": "^1.17.0",
     "graphql": "^14.3.1",
     "grip": "^1.4.0",

--- a/src/FanoutGraphqlApolloConfig.ts
+++ b/src/FanoutGraphqlApolloConfig.ts
@@ -8,6 +8,7 @@ import "core-js/es/symbol/async-iterator";
 import {
   getQueryArgumentValue,
   interpolateValueNodeWithVariables,
+  IStoredConnection,
 } from "fanout-graphql-tools";
 import {
   IEpcpPublish,
@@ -73,6 +74,8 @@ export interface INote {
 }
 
 export interface IFanoutGraphqlTables {
+  /** WebSocket-Over-Http Connections */
+  connections: ISimpleTable<IStoredConnection>;
   /** Notes table */
   notes: ISimpleTable<INote>;
   /** Subscriptions - keep track of GraphQL Subscriptions */

--- a/src/FanoutGraphqlAppLambdaCallbackTest.test.ts
+++ b/src/FanoutGraphqlAppLambdaCallbackTest.test.ts
@@ -66,6 +66,7 @@ export class FanoutGraphqlAppLambdaCallbackTest {
         url: pushpinGripUrl,
       },
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions: MapSimpleTable(),
       },
@@ -101,6 +102,7 @@ export class FanoutGraphqlAppLambdaCallbackTest {
         url: pushpinGripUrl,
       },
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions: MapSimpleTable(),
       },

--- a/src/FanoutGraphqlAwsApp.ts
+++ b/src/FanoutGraphqlAwsApp.ts
@@ -2,6 +2,7 @@ import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import * as cloud from "@pulumi/cloud";
 import { PubSubEngine } from "apollo-server";
+import { GraphqlWsOverWebSocketOverHttpStorageCleaner } from "fanout-graphql-tools"
 import FanoutGraphqlAppLambdaCallback from "./FanoutGraphqlAppLambdaCallback";
 import { IFanoutGraphqlServerGripOptions } from "./FanoutGraphqlExpressServer";
 
@@ -16,30 +17,63 @@ const FanoutGraphqlAwsApp = (
   name: string,
   options: IFanoutGraphqlAwsAppOptions,
 ) => {
-  const lambdaFunction = new aws.lambda.CallbackFunction(`${name}-fn-graphql`, {
+  const webSocketOverHttpStorage = {
+    connections: new cloud.Table(`${name}-connections`),
+    subscriptions: new cloud.Table(`${name}-subscriptions`),
+  }
+
+  // AWS Resources for serving GraphQL API over HTTP
+  const httpLambdaFunction = new aws.lambda.CallbackFunction(`${name}-fn-graphql`, {
     callback: FanoutGraphqlAppLambdaCallback({
       grip: options.grip,
       pubsub: options.pubsub,
       tables: {
-        connections: new cloud.Table(`${name}-connections`),
         notes: new cloud.Table(`${name}-notes`),
-        subscriptions: new cloud.Table(`${name}-subscriptions`),
+        ...webSocketOverHttpStorage,
       },
     }),
     timeout: 30,
   });
   const routes: awsx.apigateway.Route[] = [
     {
-      eventHandler: lambdaFunction,
+      eventHandler: httpLambdaFunction,
       method: "GET",
       path: "/",
     },
     {
-      eventHandler: lambdaFunction,
+      eventHandler: httpLambdaFunction,
       method: "POST",
       path: "/",
     },
   ];
+
+  // AWS Resources required for periodic storage cleanup.
+  /** Lambda that should be invoked periodically to clean up expired connections/subscriptions from DynamoDB */
+  const cleanupStorageLambdaFunction = new aws.lambda.CallbackFunction(`${name}-storageCleaner`, {
+    callback: async (event, context) => {
+      console.log("Begin storage cleanup lambda callback", new Date, { event, context })
+      const clean = GraphqlWsOverWebSocketOverHttpStorageCleaner({
+        connectionStorage: webSocketOverHttpStorage.connections,
+        subscriptionStorage: webSocketOverHttpStorage.subscriptions,
+      })
+      await clean()
+      console.log("End storage cleanup lambda callback")
+      return
+    }
+  })
+  /** EventRule that produces events on a regular interval that will trigger the cleanupStorageLambdaFunction */
+  const storageCleanupSchedulerEventRule = new aws.cloudwatch.EventRule(`${name}-storageCleanupScheduler`, {
+    description: "Every 1 minute",
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+    scheduleExpression: "rate(1 minute)",
+  });
+  const storageCleanupEventSubscription = new aws.cloudwatch.EventRuleEventSubscription(
+    `${name}-storageCleanup-es`,
+    storageCleanupSchedulerEventRule,
+    cleanupStorageLambdaFunction,
+    {},
+  )
+
   return { routes };
 };
 

--- a/src/FanoutGraphqlAwsApp.ts
+++ b/src/FanoutGraphqlAwsApp.ts
@@ -21,6 +21,7 @@ const FanoutGraphqlAwsApp = (
       grip: options.grip,
       pubsub: options.pubsub,
       tables: {
+        connections: new cloud.Table(`${name}-connections`),
         notes: new cloud.Table(`${name}-notes`),
         subscriptions: new cloud.Table(`${name}-subscriptions`),
       },

--- a/src/FanoutGraphqlExpressServer.ts
+++ b/src/FanoutGraphqlExpressServer.ts
@@ -192,6 +192,7 @@ export const FanoutGraphqlExpressServer = (
     .use(
       options.grip
         ? GraphqlWsOverWebSocketOverHttpExpressMiddleware({
+            connectionStorage: options.tables.connections,
             getGripChannel: FanoutGraphqlGripChannelsForSubscription,
             onSubscriptionStart: onSubscriptionConnection,
             onSubscriptionStop: options.onSubscriptionStop,
@@ -266,6 +267,7 @@ const main = async () => {
     },
     pubsub: new PubSub(),
     tables: {
+      connections: MapSimpleTable(),
       notes: MapSimpleTable<INote>(),
       subscriptions: MapSimpleTable<IGraphqlSubscription>(),
     },

--- a/src/FanoutGraphqlExpressServerTest.test.ts
+++ b/src/FanoutGraphqlExpressServerTest.test.ts
@@ -145,6 +145,7 @@ export class FanoutGraphqlExpressServerTestSuite {
       onSubscriptionConnection: setLatestSocket,
       pubsub: new PubSub(),
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions: MapSimpleTable<IGraphqlSubscription>(),
       },
@@ -185,6 +186,7 @@ export class FanoutGraphqlExpressServerTestSuite {
       },
       onSubscriptionConnection: setLatestSocket,
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions: MapSimpleTable<IGraphqlSubscription>(),
       },
@@ -277,6 +279,7 @@ export class FanoutGraphqlExpressServerTestSuite {
       },
       onSubscriptionConnection: setLatestSocket,
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions: MapSimpleTable<IGraphqlSubscription>(),
       },
@@ -325,6 +328,7 @@ export class FanoutGraphqlExpressServerTestSuite {
       onSubscriptionConnection: setLatestSocket,
       onSubscriptionStop: setLastSubscriptionStop,
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions,
       },
@@ -393,6 +397,7 @@ export class FanoutGraphqlExpressServerTestSuite {
       onSubscriptionConnection: setLatestSocket,
       onSubscriptionStop: setLastSubscriptionStop,
       tables: {
+        connections: MapSimpleTable(),
         notes: MapSimpleTable<INote>(),
         subscriptions,
       },


### PR DESCRIPTION
* FanoutGraphqlAwsApp [now has a second lambda](https://github.com/fanout/apollo-demo/pull/14/files#diff-4e06ee720685a70e308368916765e271R52) that invokes `GraphqlWsOverWebSocketOverHttpStorageCleaner` from fanout-graphql-tools. It's triggered by a periodic [scheduled cloudwatch event](https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html)

This is deployed at http://b67cf393.fanoutcdn.com/stage/
You can make connections/subscriptions there and watch the corresponding DyanmoDB tables. https://us-west-2.console.aws.amazon.com/dynamodb/home?region=us-west-2#tables:selected=demo-lambda-subscriptions-5f59bd5;tab=items

I tested enough to see that if you make some subscriptions, the db has rows for the connection/subscriptions. Then if you close the GraphiQL tab, this registers as a close or disconnect enough to [trigger storage cleanup](https://github.com/fanout/fanout-graphql-tools/blob/master/src/subscriptions-transport-ws-over-http/GraphqlWsOverWebSocketOverHttpExpressMiddleware.ts#L189), and the rows for that connection and its subscription are deleted immediately. FWIW, it appears a single GraphiQL Playground pageload makes many graphql-ws connections. Probably because each 'tab' in GraphiQL uses its own ApolloClient instance.

Because exiting GraphiQL results in a fairly clean close, I haven't really tested the connection expiration/timeout scenario. But I can see that the periodic storageCleaner lambda is being invoked via cloudwatch logs, and the actual cleaning code is the same as what's working during the onClose cleanup mentioned above.